### PR TITLE
new eck twig files for smaller headers

### DIFF
--- a/drupal/eck/eck-entity--page-header--full-width-3x1.html.twig
+++ b/drupal/eck/eck-entity--page-header--full-width-3x1.html.twig
@@ -1,0 +1,11 @@
+{% set schema = eck.field_theme_color_scheme|length? eck.field_theme_color_scheme.value : theme_settings.scheme_settings.page_header__full_width.value %}
+{% set small_image = eck.field_secondary_media.entity.field_media_image %}
+{% include 'components-hero-page-header' with {
+  headline: content.field_headline_group,
+  media: content.field_media,
+  secondary_image_url: small_image.entity.uri.value|resize('square'),
+  secondary_image_alt: small_image.alt,
+  cta_primary: content.field_cta_link,
+  cta_secondary: content.field_secondary_link,
+  slab_variant: {'white': 'slab--wildcat-white', 'dark': 'slab--dark-blue', 'wildcat': 'slab--wildcat-blue'}[schema]  
+} %}

--- a/drupal/eck/eck-entity--page-header--split-header-16x9.html.twig
+++ b/drupal/eck/eck-entity--page-header--split-header-16x9.html.twig
@@ -1,0 +1,18 @@
+{% set schema = eck.field_theme_color_scheme|length? eck.field_theme_color_scheme.value : theme_settings.scheme_settings.page_header__split_header.value %}
+{% if not content.field_media|children|length %}
+  {# fall back to simple page header #}
+  {% include 'components-text-page-header' with {
+    headline: content.field_headline_group,
+    cta_primary: content.field_cta_link,
+    cta_secondary: content.field_secondary_link,
+    slab_skin: {'white': 'slab--wildcat-white', 'gray': 'slab--blue-gray', 'dark': 'slab--dark-blue', 'wildcat': 'slab--wildcat-blue'}[schema]
+  } %}
+{% else %}
+  {% include 'components-split-page-header' with {
+    headline: content.field_headline_group,
+    media: content.field_media,
+    cta_primary: content.field_cta_link,
+    cta_secondary: content.field_secondary_link,
+    slab_variant: {'light': '', 'gray': 'slab--light-gray', 'dark': 'slab--dark-blue', 'wildcat': 'slab--wildcat-blue'}[schema]
+  } %}
+{% endif %}


### PR DESCRIPTION
Added 2 new twig files in drupal/eck for 2 new page header types which are a clone of full width and split with smaller image styles.