### PR TITLE
removed the hardcoded navingation for the people content type based on #4

### DIFF
--- a/drupal/nodes/node--person--full.html.twig
+++ b/drupal/nodes/node--person--full.html.twig
@@ -44,17 +44,6 @@
         } %}
       {% endblock %}
       {% block slab_sidebar %}
-        <div class="section-nav section-nav--blue-gray">
-          <nav aria-labelledby="sectionNavigationLabel">
-          <h2 id="sectionNavigationLabel">
-            <span class="show-for-sr">Section Navigation: </span>
-            {% include 'atoms-link' with { 
-              link_variant: 'link--fancy-reverse', 
-              label: 'Back to Directory', 
-              url: '/people' 
-            } %}
-          </h2>
-        </div>
         {{ region.sidebar }}
       {% endblock %}
   {% endembed %}


### PR DESCRIPTION
Removed the hardcoded markup from the template. Updated the configs to create a view for the person node type on the uky_base repo