### PR TITLE
Deprecated function - strip_tags

### DIFF
--- a/lib/eck.inc
+++ b/lib/eck.inc
@@ -8,7 +8,7 @@ function ukd8_preprocess_eck_entity(&$variables) {
   // Backwards compatibility.
   $variables['eck'] = $entity;
   $variables['plain_title'] = isset($variables['eck']->title) ?
-      strip_tags($variables['eck']->title[0]->value) :
+      strip_tags((string)$variables['eck']->title[0]->value) :
       '';
 
   // Load up the theme settings; see theme.inc.

--- a/lib/node.inc
+++ b/lib/node.inc
@@ -10,7 +10,9 @@ function ukd8_preprocess_node(array &$variables) {
     $node = $variables['node'];
     $type = $node->getType();
 
-    $variables['plain_title'] = strip_tags($node->title[0]->value);
+    $variables['plain_title'] = isset($node->title[0]->value) ?
+    strip_tags((string)$node->title[0]->value) :
+    '';
     $variables['is_front'] = \Drupal::service('path.matcher')->isFrontPage();
     $variables['base_path'] = base_path();
 


### PR DESCRIPTION
[ ] -added type casting to avoid passing NULL as the first parameter to strip_tags. passing NULL as a parameter is deprecated in PHP 8.1
[ ] - Fixed Warning: Attempt to read property "value" on null in ukd8_preprocess_node() (line 13 of /var/www/html/packages/uky-web/ukd8/lib/node.inc) by checking if the value `$node->title[0]->value` is present. 